### PR TITLE
SE-8842 app_group_id no longer a standalone param

### DIFF
--- a/lib/appboy/api.rb
+++ b/lib/appboy/api.rb
@@ -13,18 +13,5 @@ module Appboy
     include Appboy::Endpoints::ScheduleMessages
     include Appboy::Endpoints::EmailStatus
 
-    def export_users(**payload)
-      Appboy::REST::ExportUsers.new.perform(app_group_id, payload)
-    end
-
-    def list_segments
-      Appboy::REST::ListSegments.new.perform(app_group_id)
-    end
-
-    attr_reader :app_group_id
-
-    def initialize(app_group_id)
-      @app_group_id = app_group_id
-    end
   end
 end

--- a/lib/appboy/endpoints/email_status.rb
+++ b/lib/appboy/endpoints/email_status.rb
@@ -2,7 +2,7 @@ module Appboy
   module Endpoints
     module EmailStatus
       def email_status(**payload)
-        email_status_service.new(app_group_id, payload).perform
+        email_status_service.new(payload).perform
       end
 
       def email_status_service

--- a/lib/appboy/endpoints/schedule_messages.rb
+++ b/lib/appboy/endpoints/schedule_messages.rb
@@ -2,7 +2,7 @@ module Appboy
   module Endpoints
     module ScheduleMessages
       def schedule_messages(**payload)
-        schedule_messages_service.new(app_group_id, payload).perform
+        schedule_messages_service.new(payload).perform
       end
 
       private

--- a/lib/appboy/endpoints/send_messages.rb
+++ b/lib/appboy/endpoints/send_messages.rb
@@ -2,7 +2,7 @@ module Appboy
   module Endpoints
     module SendMessages
       def send_messages(**payload)
-        send_messages_service.new(app_group_id, payload).perform
+        send_messages_service.new(payload).perform
       end
 
       private

--- a/lib/appboy/endpoints/track_users.rb
+++ b/lib/appboy/endpoints/track_users.rb
@@ -4,7 +4,7 @@ module Appboy
       attr_writer :track_users_service
 
       def track_users(**payload)
-        track_users_service.perform(app_group_id, payload)
+        track_users_service.perform(payload)
       end
 
       def track_purchase(payload)

--- a/lib/appboy/rest/schedule_messages.rb
+++ b/lib/appboy/rest/schedule_messages.rb
@@ -4,7 +4,7 @@ module Appboy
 
       attr_reader :app_group_id, :send_at, :messages, :segment_id, :local_timezone, :external_user_ids, :campaign_id
 
-      def initialize(app_group_id, send_at:, messages: [], external_user_ids: [], local_timezone: false, campaign_id: nil, segment_id: nil, logger: nil)
+      def initialize(app_group_id:, send_at:, messages: [], external_user_ids: [], local_timezone: false, campaign_id: nil, segment_id: nil, logger: nil)
         @app_group_id = app_group_id
         @send_at = send_at
         @messages = messages

--- a/lib/appboy/rest/send_messages.rb
+++ b/lib/appboy/rest/send_messages.rb
@@ -4,7 +4,7 @@ module Appboy
 
       attr_reader :app_group_id, :messages, :external_user_ids, :segment_id, :campaign_id
 
-      def initialize(app_group_id, messages: [], external_user_ids: [], campaign_id: nil, segment_id: nil, logger: nil)
+      def initialize(app_group_id:, messages: [], external_user_ids: [], campaign_id: nil, segment_id: nil, logger: nil)
         @app_group_id = app_group_id
         @messages = messages
         @external_user_ids = external_user_ids

--- a/spec/appboy/rest/schedule_messages_spec.rb
+++ b/spec/appboy/rest/schedule_messages_spec.rb
@@ -4,15 +4,14 @@ describe Appboy::REST::ScheduleMessages do
   let(:http) { double(:http) }
 
   let(:payload) {{
+    app_group_id: :app_group_id,
     send_at: :send_at,
     segment_id: :segment_id,
     local_timezone: :local_timezone,
     messages: :messages
   }}
 
-  let(:app_group_id) { :app_group_id }
-
-  subject { described_class.new(app_group_id, payload) }
+  subject { described_class.new(payload) }
 
   before { subject.http = http }
 
@@ -24,7 +23,7 @@ describe Appboy::REST::ScheduleMessages do
 
   def expect_schedule_messages_http_call
     expect(http).to receive(:post).with '/messages/schedule', {
-      app_group_id: app_group_id,
+      app_group_id: :app_group_id,
       segment_ids: [:segment_id],
       send_at: :send_at,
       deliver_in_local_timezone: :local_timezone,

--- a/spec/appboy/rest/send_messages_spec.rb
+++ b/spec/appboy/rest/send_messages_spec.rb
@@ -4,12 +4,11 @@ describe Appboy::REST::SendMessages do
   let(:http) { double(:http) }
 
   let(:payload) {{
+    app_group_id: :app_group_id,
     messages: :messages,
     external_user_ids: :external_user_ids,
     segment_id: :segment_id
   }}
-
-  let(:app_group_id) { :app_group_id }
 
   subject { described_class.new(app_group_id,
     messages: :messages,


### PR DESCRIPTION
this change to appboy is to make the app_group_id part of the parameters hash.

originally the app_group_id was a standalone param to the initialize method.

we could leave the appboy api unchanged and create separate api clients from the se app, but I failed to see the benefit of giving the app_group_id param the special treatment it was getting. bundling it as part of the params hash seems more straightforward as we can just encapsulate all the information the notification needs to send itself, and this in turn keeps the push.rb code simpler.